### PR TITLE
set seed in output file name

### DIFF
--- a/AlgSimu/share/JobOpt_DmpSim
+++ b/AlgSimu/share/JobOpt_DmpSim
@@ -21,7 +21,7 @@ DMPSW.Core.Set("EventNumber","10")     # MUST event number for simulation!!!
 
 #-------------------------------------------------------------------
 # RootIOSvc options
-#DMPSW.RootIOSvc.Set("Input/FileName","./Ex_pion.mac")   # if NOT set, will invoke visualization mode
+DMPSW.RootIOSvc.Set("Input/FileName","./Ex_pion.mac")   # if NOT set, will invoke visualization mode
 #DMPSW.RootIOSvc.Set("Input/FileName","./Ex_proton.mac")      # if NOT set, will invoke visualization mode
 #DMPSW.RootIOSvc.Set("Input/FileName","./Ex_electron.mac")    # if NOT set, will invoke visualization mode
 #DMPSW.RootIOSvc.Set("Output/FileName","./testxxxmpSimData_test00.root")        # if NOT set, will use the input macro name
@@ -41,7 +41,7 @@ simAlg.Set("Physics","QGSP_BERT")  # If NOT set, will use QGSP_BIC. argv = {QGSP
 #simAlg.Set("Gdml",DMPSW.SysPath+"/share/Geometry/EQM")     # must set the path
 #simAlg.Set("Gdml",DMPSW.SysPath+"/share/Geometry/BeamTestOctober2014")     # must set the path
 simAlg.Set("Gdml","../../Geometry/BeamTestOctober2014")     # must set the path
-simAlg.Set("Seed","1411681994")
+simAlg.Set("Seed","1411742744")
 #simAlg.Set("Gdml","../../Geometry/EQM")     # must set the path
 
 #-------------------------------------------------------------------

--- a/AlgSimu/src/DmpSimAlg.cc
+++ b/AlgSimu/src/DmpSimAlg.cc
@@ -5,6 +5,7 @@
 */
 
 #include <time.h>   // time_t
+#include <boost/lexical_cast.hpp>
 
 #include "DmpSimAlg.h"
 #include "DmpSimRunManager.h"
@@ -47,7 +48,7 @@ DmpSimAlg::DmpSimAlg()
       gRootIOSvc->Set("Output/FileName","DmpSimVis.root");
     }
   }
-  gRootIOSvc->Set("Output/Key","sim");
+  gRootIOSvc->Set("Output/Key",boost::lexical_cast<std::string>(fSeed)+"-sim");
 }
 
 //-------------------------------------------------------------------
@@ -57,7 +58,6 @@ DmpSimAlg::~DmpSimAlg(){
 }
 
 //-------------------------------------------------------------------
-#include <boost/lexical_cast.hpp>
 //#include "DmpEvtMCNudBlock.h"
 void DmpSimAlg::Set(const std::string &type,const std::string &argv){
   if(OptMap.find(type) == OptMap.end()){
@@ -87,6 +87,7 @@ void DmpSimAlg::Set(const std::string &type,const std::string &argv){
     case 3: // Seed
     {
       fSeed = boost::lexical_cast<long>(argv);
+      gRootIOSvc->Set("Output/Key",argv+"-sim");
       break;
     }
     case 4: // Auxiliary detector offset X


### PR DESCRIPTION
If someone got a output file of simulation, and he/she wants to creat the exactly same simulation results as that output simulation file. How to do it?  so, add seed as a part of output file name.
